### PR TITLE
Fix typo to extend React.Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ class BSRow extends React.Component {
   }
 }
 
-class SomeView extends React.createClass {
+class SomeView extends React.Component {
   render () {
     return (
       <BSRow>


### PR DESCRIPTION
The example was previously `extends React.createClass`.