### PR TITLE
Removed comma after methods in Person Class

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,15 +78,15 @@ class Person extends React.Component {
 
   componentWillMount () {
     // add event listeners (Flux Store, WebSocket, document, etc.)
-  },
+  }
 
   componentDidMount () {
     // React.getDOMNode()
-  },
+  }
 
   componentWillUnmount () {
     // remove event listeners (Flux Store, WebSocket, document, etc.)
-  },
+  }
 
   get smilingMessage () {
     return (this.state.smiling) ? "is smiling" : "";
@@ -98,7 +98,7 @@ class Person extends React.Component {
         {this.props.name} {this.smilingMessage}
       </div>
     );
-  },
+  }
 }
 
 Person.defaultProps = {


### PR DESCRIPTION
The Person class example contained comma after methods, which is not a valid ES6 Class syntax. Hence , removed these entries.
Reference: [Classes Reference on MDN](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Classes)